### PR TITLE
Fix max date and min pity on wish counter add modal

### DIFF
--- a/src/components/WishCounterAddModal.svelte
+++ b/src/components/WishCounterAddModal.svelte
@@ -85,11 +85,11 @@
     <CharacterSelect bind:selected={name} />
   {/if}
   <div class="h-4" />
-  <Input type="datetime-local" step="1" bind:value={time} />
+  <Input type="datetime-local" step="1" max="9999-12-31T23:59:59" bind:value={time} />
   <div class="h-4" />
   <div class="flex items-center">
     <p class="ml-4 mr-4">At Pity:</p>
-    <Input type="number" bind:value={pity} />
+    <Input type="number" min="1" bind:value={pity} />
   </div>
   {#if isEdit}
     <div class="flex mt-32">

--- a/src/routes/wish/_counter.svelte
+++ b/src/routes/wish/_counter.svelte
@@ -392,7 +392,7 @@
           <div class="bg-background rounded-xl w-full px-4 mr-2 flex items-center">
             <span>Click the list to edit or delete</span>
           </div>
-          <Button size="sm" className="w-16" on:click={() => openAddModal(0)}>Add</Button>
+          <Button size="sm" className="w-16" on:click={() => openAddModal(1)}>Add</Button>
         </div>
       {/if}
       <div class="flex">


### PR DESCRIPTION
This commit is supposed to:
* prevent the date from exceeding 4 characters, to be able to easily type date and time in one go from the keyboard (no mouse or arrow keys needed to switch between date and time)
* prevent the pity to be set to values lower than 1
* make the Add Modal, when opened from the "Add" button, to have the pity counter set to 1 by default

Screenshot with the issues:

<img src="https://user-images.githubusercontent.com/13729459/122656003-a711ec00-d15f-11eb-8081-422183db0c3a.png" width="40%">

