### PR TITLE
Add fundamental import support for GenshinWishes

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -251,6 +251,7 @@
       "subtitle": "Select where your excel come from:",
       "default": "Paimon.moe Export",
       "takagg": "TakaGG Gacha Export",
+      "genshinwishes": "GenshinWishes Export",
       "notice": [
         "This feature still in BETA please backup first by going to Setting then Export to Excel!",
         "Wish with the same timestamp and reward name will NOT be touched (so existing wish will not be rewritten)",
@@ -259,7 +260,8 @@
       ],
       "selectFile": {
         "default": "Drag & drop Paimon.moe excel file here, or click here to select",
-        "takagg": "Drag & drop TakaGG gacha export excel file here, or click here to select"
+        "takagg": "Drag & drop TakaGG gacha export excel file here, or click here to select",
+        "genshinwishes": "Drag & drop GenshinWishes excel file, converted from csv, here, or click here to select"
       },
       "processing": "Processing...",
       "addedOn": "Inserted on the:",


### PR DESCRIPTION
The only issue is that genshin-wishes.com exports the wishes as a single .csv file.
I know that exceljs also supports csv but I don't know which way would be the best to implement.
I didn't want to change the import code structure too much; therefore the .csv has to be converted to .xlsx first.