### PR TITLE
Fix toggling 3-stage achievements

### DIFF
--- a/src/components/Check.svelte
+++ b/src/components/Check.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <label
-  class="checkbox-wrapper flex flex-1 pl-4 items-center rounded-2xl h-14 cursor-pointer {inverted
+  class="checkbox-wrapper flex flex-1 pl-4 items-center rounded-2xl h-14 {disabled ? 'cursor-not-allowed' : 'cursor-pointer'} {inverted
     ? 'bg-item'
     : 'bg-background'} {className}"
   style="--bg: {inverted ? '#202442' : '#2D325A'};"

--- a/src/routes/achievement/index.svelte
+++ b/src/routes/achievement/index.svelte
@@ -147,6 +147,13 @@
       val = !list[index][subindex].checked;
       list[index][subindex].checked = val;
       checkList[active][list[index][subindex].id] = val;
+
+      // If unchecked, recursively uncheck subsequent achievements
+      if (subindex < list[index].length - 1 &&
+          !list[index][subindex].checked &&
+          list[index][subindex + 1].checked) {
+        toggle({ index, subindex: subindex + 1, primogem: list[index][subindex + 1].reward});
+      }
     } else {
       val = !list[index].checked;
       list[index].checked = val;
@@ -284,6 +291,7 @@
                     checked={list[index][i].checked}
                     on:change={() => toggle({ index, subindex: i, primogem: it.reward })}
                     inverted
+                    disabled={i > 0 && !el[i - 1].checked}
                   />
                 </div>
               </div>


### PR DESCRIPTION
I started tracking my achievements on Paimon.moe and noticed a bug (or rather lack of feature) that allows users to check off second or third achievements before they checked off the preceding achievement.

The pull request also prevents the checkbox from being clicked when disabled and adds a `cursor-not-allowed` Tailwind class.

Here is the current behavior:
![before](https://i.imgur.com/Az9fqzv.gif)

Here is the pull request result:
![after](https://i.imgur.com/fTs6qx7.gif)

I tried my best to not change too much of the existing code but found that the `toggle()` function did too many things for a toggling functionality and realized that it was too restrictive when extending. Perhaps you might want to take a look and refactor if possible, extracting some functionality out to separate functions to reuse?
