### PR TITLE
fix: Correct a calculation bug when computing avg pity by type

### DIFF
--- a/src/routes/wish/_summary.svelte
+++ b/src/routes/wish/_summary.svelte
@@ -79,7 +79,7 @@
     },
   };
 
-  
+
 
   export async function readLocalData() {
     let totalWish = 0;
@@ -194,12 +194,12 @@
             weapon: {
               total: rareWeapon,
               percentage: total > 0 ? rareWeapon / total : 0,
-              pity: rare > 0 ? rarePityWeapon / rare : 0,
+              pity: rareWeapon > 0 ? rarePityWeapon / rareWeapon : 0,
             },
             character: {
               total: rareCharacter,
               percentage: total > 0 ? rareCharacter / total : 0,
-              pity: rare > 0 ? rarePityCharacter / rare : 0,
+              pity: rareCharacter > 0 ? rarePityCharacter / rareCharacter : 0,
             },
           },
           legendary: {


### PR DESCRIPTION
I noticed the numbers for average character and weapon pity looked weird in the summary section, so I poked around in the code.

I think I found a fix, so just wanted to push that up!

Before:

<img width="383" alt="Screen Shot 2021-09-08 at 11 33 45 pm" src="https://user-images.githubusercontent.com/11449340/132636325-a428e8f5-4280-4e86-9503-51543a749b5d.png">

After:

<img width="385" alt="Screen Shot 2021-09-08 at 11 32 43 pm" src="https://user-images.githubusercontent.com/11449340/132636350-82b57716-3eaf-4f9e-86d9-484e74b7663a.png">

Stats are based on this mock data:

<img width="396" alt="Screen Shot 2021-09-08 at 11 47 38 pm" src="https://user-images.githubusercontent.com/11449340/132636616-640494fe-7bbd-4caf-b7d9-478e36051cc5.png">