### PR TITLE
Make Circlet Crit Damage in Ganyu's freeze comp

### DIFF
--- a/src/data/build.js
+++ b/src/data/build.js
@@ -1026,7 +1026,7 @@ export const builds = {
         mainStats: {
           sands: 'ATK%',
           goblet: 'Cryo DMG',
-          circlet: 'Crit Rate',
+          circlet: 'Crit DMG',
         },
         subStats: ['Crit Rate / DMG', 'ATK%', 'Energy Recharge', 'Flat ATK'],
         talent: ['Normal Attack', 'Burst', 'Skill'],


### PR DESCRIPTION
In accordance to issue #153, I have changed the Crit Rate Circlet to Crit DMG. I'm not sure if this change was actually desired, but I have make the pull request just in case.