### PR TITLE
P in Paimon.moe in Spanish locale

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -623,7 +623,7 @@
     "or": "O"
   },
   "footer": {
-    "affliate": "aimon.moe no está afiliado a miHoYo.",
+    "affliate": "Paimon.moe no está afiliado a miHoYo.",
     "copyright": "Genshin Impact, el contenido del juego y los materiales son marcas comerciales y derechos de autor de miHoYo.",
     "discord": "Únete a nuestro Discord",
     "community": "Enlaces a la comunidad",


### PR DESCRIPTION
I found a typo in the name of the page in the "Affiliation" part of the footer, Spanish language.