### PR TITLE
QOL improvement to PC wish counter imports

### DIFF
--- a/src/components/WishImportModal.svelte
+++ b/src/components/WishImportModal.svelte
@@ -119,7 +119,7 @@
     processingLog = true;
 
     try {
-      if (selectedType === 'android') {
+      if (selectedType === 'android' || selectedType == 'pc') {
         const urlString = genshinLink.match(/https:\/\/.*\//g);
         url = new URL(urlString);
       } else {


### PR DESCRIPTION
Apply the same type of RegEx matching that we already have setup for Android imports to URLs submitted to PC imports.

This rectifies the common mistake of users including the "OnGetWebViewPageFinish:" in the URL. Without this statement, if a user submits a URL starting with "OnGetWebViewPageFinish:", then the wish counter will throw the error "Error code returned from MiHoYo API, please try again later! (500)".

Let me know if there are anything that I may be overlooking when it comes to the PC imports.