### PR TITLE
Add commission's primogem to totalPrimogem in Fate Count Calculator

### DIFF
--- a/src/routes/calculator/_fateCount.svelte
+++ b/src/routes/calculator/_fateCount.svelte
@@ -60,6 +60,7 @@
     }
     if (parameters[0].amount>0) {
       let total = parameters[0].amount*60;
+      totalPrimogem += total;
       result.push({name: $t('calculator.fateCount.dailyCommission'), image: "/images/commission.png", amount: parameters[0].amount, total: total})
     }
   }


### PR DESCRIPTION
Fix the bug that commission's primogem isn't included in total primogem count