### PR TITLE
Add japanese yen.

### DIFF
--- a/src/routes/calculator/_fates.svelte
+++ b/src/routes/calculator/_fates.svelte
@@ -55,6 +55,10 @@
       currency: 'S$',
       values: [1.48, 6.98, 21.98, 44.98, 68.98, 148.98],
     },
+    YEN: {
+      currency: '¥',
+      values: [120, 610, 1840, 3680, 6100, 12000],
+    },
     Custom: {
       currency: 'Custom',
       values: [0.99, 4.99, 14.99, 29.99, 49.99, 99.99],
@@ -75,6 +79,7 @@
     { label: 'GBP (£)', value: 'GBP' },
     { label: 'CNY (¥)', value: 'CNY' },
     { label: 'SGD (S$)', value: 'SGD' },
+    { label: 'YEN (円)', value: 'YEN' },
     { label: 'Custom', value: 'Custom' },
   ];
 


### PR DESCRIPTION
Add japanese yen preset to fates caluculator.

## Before
<img width="801" alt="スクリーンショット 2022-05-20 23 53 24" src="https://user-images.githubusercontent.com/2792624/169554872-408a7b00-68e6-46a6-8ecb-695fc1e9aba3.png">

## After
<img width="1114" alt="スクリーンショット 2022-05-20 23 52 27" src="https://user-images.githubusercontent.com/2792624/169554690-ecd7e1e1-bddd-4e4e-a7bb-fd92de1d5d10.png">

## Shop images in Japanese
<img width="1366" alt="IMG_60FD177378A5-1" src="https://user-images.githubusercontent.com/2792624/169555558-5a37f1e7-ddcb-48aa-ac3d-0648d9a005f4.png">

