### PR TITLE
Localize "Win 50:50"

### DIFF
--- a/src/routes/wish/_summaryItem.svelte
+++ b/src/routes/wish/_summaryItem.svelte
@@ -51,7 +51,7 @@
     {#if avg.legendary.rateOff !== undefined}
       <tr>
         <td class="text-legendary-from font-semibold pl-4 md:pl-4 pr-2 md:pr-4 border-t border-gray-700">
-          └ Win 50:50
+          └ {$t('wish.summary.winRateOff')}
         </td>
         <td class="text-legendary-from font-semibold pr-2 md:pr-4 text-right border-t border-gray-700">
           {numberFormat.format(avg.legendary.rateOff.total)}


### PR DESCRIPTION
Baruna seems to forget to localize one string again. Don't worry, this doesn't need a locale update.