### PR TITLE
Add cumulative pity for featured/banner character.

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -452,6 +452,7 @@
       "pityAverage": "",
       "character": "",
       "weapon": "",
+      "featured": "",
       "winRateOff": "",
       "winRateOffWeapon": ""
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -452,6 +452,7 @@
       "pityAverage": "Pity AVG",
       "character": "Character",
       "weapon": "Weapon",
+      "featured": "Featured",
       "winRateOff": "Win 50:50",
       "winRateOffWeapon": "Win 75:25"
     },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -452,6 +452,7 @@
       "pityAverage": "",
       "character": "",
       "weapon": "",
+      "featured": "",
       "winRateOff": "",
       "winRateOffWeapon": ""
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -452,6 +452,7 @@
       "pityAverage": "Pity MOY",
       "character": "Personnage",
       "weapon": "Arme",
+      "featured": "Bannière",
       "winRateOff": "Gagne le 50:50",
       "winRateOffWeapon": ""
     },

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -452,6 +452,7 @@
       "pityAverage": "Rerata Pity",
       "character": "Karakter",
       "weapon": "Senjata",
+      "featured": "Promotional",
       "winRateOff": "Menang 50:50",
       "winRateOffWeapon": "Win 75:25"
     },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -452,6 +452,7 @@
       "pityAverage": "天井カウント数の平均",
       "character": "キャラクター",
       "weapon": "武器",
+      "featured": "ピックアップ",
       "winRateOff": "排出",
       "winRateOffWeapon": ""
     },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -452,6 +452,7 @@
       "pityAverage": "",
       "character": "",
       "weapon": "",
+      "featured": "",
       "winRateOff": "",
       "winRateOffWeapon": ""
     },

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -452,6 +452,7 @@
       "pityAverage": "",
       "character": "",
       "weapon": "",
+      "featured": "",
       "winRateOff": "",
       "winRateOffWeapon": ""
     },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -452,6 +452,7 @@
       "pityAverage": "Среднее значение",
       "character": "Персонаж",
       "weapon": "Оружие",
+      "featured": "Баннера",
       "winRateOff": "Выигрыш 50:50",
       "winRateOffWeapon": ""
     },

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -452,6 +452,7 @@
       "pityAverage": "",
       "character": "",
       "weapon": "",
+      "featured": "",
       "winRateOff": "",
       "winRateOffWeapon": ""
     },

--- a/src/locales/tw.json
+++ b/src/locales/tw.json
@@ -452,6 +452,7 @@
       "pityAverage": "出貨均數",
       "character": "角色",
       "weapon": "武器",
+      "featured": "當期UP",
       "winRateOff": "小保底沒歪",
       "winRateOffWeapon": ""
     },

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -452,6 +452,7 @@
       "pityAverage": "Lượt Ra TB",
       "character": "Nhân Vật",
       "weapon": "Vũ Khí",
+      "featured": "Rate-up",
       "winRateOff": "Thắng 50:50",
       "winRateOffWeapon": ""
     },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -452,6 +452,7 @@
       "pityAverage": "出货均数",
       "character": "角色",
       "weapon": "武器",
+      "featured": "当期UP",
       "winRateOff": "小保底没歪",
       "winRateOffWeapon": ""
     },

--- a/src/routes/wish/_summary.svelte
+++ b/src/routes/wish/_summary.svelte
@@ -232,6 +232,13 @@
                 counterData.rateoff.legendary.win /
                 (counterData.rateoff.legendary.win + counterData.rateoff.legendary.lose),
             };
+            avg[type.id].legendary.featured = {
+              total: avg[type.id].legendary.total - counterData.rateoff.legendary.lose,
+              percentage:
+                (avg[type.id].legendary.total - counterData.rateoff.legendary.lose) /
+                avg[type.id].legendary.total,
+              pity: legendary > 0 ? legendaryPity / (avg[type.id].legendary.total - counterData.rateoff.legendary.lose) : 0,
+            };
 
             percentages[type.id].winRateOff.legendary = avg[type.id].legendary.rateOff.percentage;
           }

--- a/src/routes/wish/_summaryItem.svelte
+++ b/src/routes/wish/_summaryItem.svelte
@@ -51,6 +51,21 @@
     {#if avg.legendary.rateOff !== undefined}
       <tr>
         <td class="text-legendary-from font-semibold pl-4 md:pl-4 pr-2 md:pr-4 border-t border-gray-700">
+          └ {$t('wish.summary.featured')}
+        </td>
+        <td class="text-legendary-from font-semibold pr-2 md:pr-4 text-right border-t border-gray-700">
+          {numberFormat.format(avg.legendary.featured.total)}
+        </td>
+        <td class="text-legendary-from font-semibold pr-2 md:pr-4 text-right border-t border-gray-700">
+          {numberFormat.format(avg.legendary.featured.percentage * 100)}%
+        </td>  
+        <td class="text-legendary-from font-semibold text-right border-t border-gray-700">
+          {numberFormat.format(avg.legendary.featured.pity)}
+        </td>
+        <td class="text-legendary-from font-semibold text-right border-t border-gray-700" />
+      </tr>
+      <tr>
+        <td class="text-legendary-from font-semibold pl-4 md:pl-4 pr-2 md:pr-4 border-t border-gray-700">
           └ {$t(type.id === 'weapon-event' ? 'wish.summary.winRateOffWeapon' : 'wish.summary.winRateOff')}
         </td>
         <td class="text-legendary-from font-semibold pr-2 md:pr-4 text-right border-t border-gray-700">


### PR DESCRIPTION
This will give you a more general statistic which accounts for your luck in both pity and winning 50:50. Related to suggestion #177.

Example: 75 avg. pity with 50:50 rate of 50% yields 112.5 featured/banner character on average.