### PR TITLE
bugfix/issue-287 - fix ascension star update for char and weapon

### DIFF
--- a/src/routes/calculator/_character.svelte
+++ b/src/routes/calculator/_character.svelte
@@ -132,7 +132,7 @@
       minAscension = 0;
     }
 
-    currentAscension = Math.max(currentAscension, minAscension);
+    currentAscension = minAscension;
   }
 
   function updateMinIntendedAscension() {
@@ -152,7 +152,7 @@
       minIntendedAscension = 0;
     }
 
-    intendedAscension = Math.max(intendedAscension, minIntendedAscension);
+    intendedAscension = minIntendedAscension;
   }
 
   function updateMaxTalentLevel() {

--- a/src/routes/calculator/_weapon.svelte
+++ b/src/routes/calculator/_weapon.svelte
@@ -135,7 +135,7 @@
       minAscension = 0;
     }
 
-    currentAscension = Math.max(currentAscension, minAscension);
+    currentAscension = minAscension;
   }
 
   function updateMinIntendedAscension() {
@@ -155,7 +155,7 @@
       minIntendedAscension = 0;
     }
 
-    intendedAscension = Math.max(intendedAscension, minIntendedAscension);
+    intendedAscension = minIntendedAscension;
   }
 
   function onChange() {


### PR DESCRIPTION
**Issue ref:** https://github.com/MadeBaruna/paimon-moe/issues/287

Small bugfix. After setting the **Current** or **Intended** ascension. The stars would always be set the same or greater due to `Math.max`. Removing allows the stars to change as per User Input correctly.

Note: never used svelte, but this could be better turned into a universal **Ascension function** that returns the num of ascension stars