### PR TITLE
feat(#319): add char + weapon run counter to banner

### DIFF
--- a/src/routes/banners/index.svelte
+++ b/src/routes/banners/index.svelte
@@ -69,12 +69,13 @@
             pos: pos5,
             length: 0,
           };
-          _names5[pos5] = { name: characters[char].name, length: 0 };
+          _names5[pos5] = { name: characters[char].name, length: 0, runs: 1 };
           _rows5[pos5] = [...new Array(len).fill({ l: '' }), { char, l: 0 }];
           pos5++;
         } else {
           _rows5[_chars5[char].pos][len] = { char, l: 0 };
           _names5[_chars5[char].pos].length = 0;
+          _names5[_chars5[char].pos].runs++;
           _chars5[char].length = 0;
         }
       }
@@ -85,12 +86,13 @@
             pos: pos4,
             length: 0,
           };
-          _names4[pos4] = { name: characters[char].name, length: 0 };
+          _names4[pos4] = { name: characters[char].name, length: 0, runs: 1 };
           _rows4[pos4] = [...new Array(len).fill({ l: '' }), { char, l: 0 }];
           pos4++;
         } else {
           _rows4[_chars4[char].pos][len] = { char, l: 0 };
           _names4[_chars4[char].pos].length = 0;
+          _names4[_chars4[char].pos].runs++;
           _chars4[char].length = 0;
         }
       }
@@ -147,12 +149,13 @@
             pos: pos5,
             length: 0,
           };
-          _names5[pos5] = { name: weaponList[char].name, length: 0 };
+          _names5[pos5] = { name: weaponList[char].name, length: 0, runs: 1 };
           _rows5[pos5] = [...new Array(len).fill({ l: '' }), { char, l: 0 }];
           pos5++;
         } else {
           _rows5[_chars5[char].pos][len] = { char, l: 0 };
           _names5[_chars5[char].pos].length = 0;
+          _names5[_chars5[char].pos].runs++;
           _chars5[char].length = 0;
         }
       }
@@ -163,12 +166,13 @@
             pos: pos4,
             length: 0,
           };
-          _names4[pos4] = { name: weaponList[char].name, length: 0 };
+          _names4[pos4] = { name: weaponList[char].name, length: 0, runs: 1 };
           _rows4[pos4] = [...new Array(len).fill({ l: '' }), { char, l: 0 }];
           pos4++;
         } else {
           _rows4[_chars4[char].pos][len] = { char, l: 0 };
           _names4[_chars4[char].pos].length = 0;
+          _names4[_chars4[char].pos].runs++;
           _chars4[char].length = 0;
         }
       }
@@ -277,7 +281,11 @@
                 >
               {/if}
             {/each}
-            <td class="border border-gray-600 text-white px-2 text-xs">{$t(names[rowIndex].name)}</td>
+            {#if names[rowIndex].runs}
+              <td class="border border-gray-600 text-white px-2 text-xs">{$t(names[rowIndex].name)} ({names[rowIndex].runs})</td>
+            {:else}
+              <td class="border border-gray-600 text-white px-2 text-xs">{$t(names[rowIndex].name)}</td>
+            {/if}
           </tr>
         {/each}
         {#each rowsWep as r, rowIndex}
@@ -295,9 +303,15 @@
                 >
               {/if}
             {/each}
-            <td class="border border-gray-600 text-white px-2 text-xs max-w-[2rem] whitespace-pre-wrap"
-              >{$t(namesWep[rowIndex].name)}</td
-            >
+            {#if namesWep[rowIndex].runs}
+              <td class="border border-gray-600 text-white px-2 text-xs max-w-[2rem] whitespace-pre-wrap"
+                >{$t(namesWep[rowIndex].name)} ({namesWep[rowIndex].runs})</td
+              >
+            {:else}
+              <td class="border border-gray-600 text-white px-2 text-xs max-w-[2rem] whitespace-pre-wrap"
+                >{$t(namesWep[rowIndex].name)}</td
+              >
+            {/if}
           </tr>
         {/each}
       </tbody>


### PR DESCRIPTION
This bit of information will be helpful to see how many times a char has ben run without needing to manually count the # of icons.

For the ticket I created (#319)

5 stars characters:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/9943953/196632426-cd437cde-e6e1-4aa3-ba2d-d126b19afe5b.png">


4 stars characters:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/9943953/196632472-2c2df08f-97cb-418c-9c3d-1276a4b317a4.png">


5 star weapons:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/9943953/196632589-7461706e-f3b6-4e3c-9b0b-3bbf70623e87.png">

4 star weapons:
<img width="362" alt="image" src="https://user-images.githubusercontent.com/9943953/196632650-08d26c36-a54e-4a22-a38a-098f9eb9035f.png">
