### PR TITLE
Some item name displays are now i18n

### DIFF
--- a/src/components/TodoDeleteModal.svelte
+++ b/src/components/TodoDeleteModal.svelte
@@ -17,7 +17,7 @@
         src={`/images/weapons/${todo.weapon ? todo.weapon.id : 'any_weapon_1'}.png`}
         alt={todo.weapon ? todo.weapon.name : `Weapon Level ${todo.level.from}-${todo.level.to}`} />
       <div class="flex-1">
-        <p class="font-bold">{todo.weapon ? todo.weapon.name : 'Weapon'}</p>
+        <p class="font-bold">{todo.weapon ? $t(todo.weapon.name) : 'Weapon'}</p>
         <p class="text-gray-500">Level {`${todo.level.from}-${todo.level.to}`}</p>
       </div>
     {:else if todo.type === 'character'}
@@ -26,7 +26,7 @@
         src={`/images/characters/${todo.character ? todo.character.id : 'characters'}.png`}
         alt={todo.character ? todo.character.name : `Character Level ${todo.level.from}-${todo.level.to}`} />
       <div class="flex-1">
-        <p class="font-bold">{todo.character ? todo.character.name : 'Character'}</p>
+        <p class="font-bold">{todo.character ? $t(todo.character.name) : 'Character'}</p>
         <p class="text-gray-500">Level {`${todo.level.from}-${todo.level.to}`}</p>
       </div>
     {/if}

--- a/src/routes/calculator/_character.svelte
+++ b/src/routes/calculator/_character.svelte
@@ -542,7 +542,7 @@
                   <img class="h-6 inline-block mr-1" src={res.image} alt={res.label} />
                 </span>
               {/if}
-              {res.label}
+              {$t(res.label)}
             </span>
           </Checkbox>
         </div>
@@ -649,7 +649,7 @@
                           <img class="h-6 inline-block mr-1" src={res.image} alt={res.label} />
                         </span>
                       {/if}
-                      {res.label}
+                      {$t(res.label)}
                     </span>
                   </td>
                 </tr>

--- a/src/routes/calculator/_character.svelte
+++ b/src/routes/calculator/_character.svelte
@@ -669,7 +669,7 @@
                       <span class="w-6 inline-block">
                         <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={item.name} />
                       </span>
-                      {item.name}
+                      {$t(item.name)}
                     </span>
                   </td>
                 </tr>

--- a/src/routes/calculator/_fateCount.svelte
+++ b/src/routes/calculator/_fateCount.svelte
@@ -94,7 +94,7 @@
           <div class="mb-1 rounded-xl border-background border p-2">
             <div class="flex flex-row items-center mb-1">
               <img src={value.image} alt={value.name} class="w-6 mr-2" />
-              <p class="text-white">{value.name}</p>
+              <p class="text-white">{$t(value.name)}</p>
             </div>
             <div class="flex flex-row items-center">
               <div class="w-full">
@@ -155,7 +155,7 @@
                   <td class="border-t border-gray-700 text-white pr-2">
                     <span class="inline-flex align-middle">
                       {#if res.image !== null}<img src={res.image} alt={res.name} class="w-6 h-6 mr-2" />{/if}
-                      <p class="text-white">{res.name}</p>
+                      <p class="text-white">{$t(res.name)}</p>
                     </span>
                   </td>
                   <td class="border-t border-gray-700 text-white pr-2 text-center">

--- a/src/routes/calculator/_fateCount.svelte
+++ b/src/routes/calculator/_fateCount.svelte
@@ -94,7 +94,7 @@
           <div class="mb-1 rounded-xl border-background border p-2">
             <div class="flex flex-row items-center mb-1">
               <img src={value.image} alt={value.name} class="w-6 mr-2" />
-              <p class="text-white">{$t(value.name)}</p>
+              <p class="text-white">{value.name}</p>
             </div>
             <div class="flex flex-row items-center">
               <div class="w-full">
@@ -155,7 +155,7 @@
                   <td class="border-t border-gray-700 text-white pr-2">
                     <span class="inline-flex align-middle">
                       {#if res.image !== null}<img src={res.image} alt={res.name} class="w-6 h-6 mr-2" />{/if}
-                      <p class="text-white">{$t(res.name)}</p>
+                      <p class="text-white">{res.name}</p>
                     </span>
                   </td>
                   <td class="border-t border-gray-700 text-white pr-2 text-center">

--- a/src/routes/calculator/_weapon.svelte
+++ b/src/routes/calculator/_weapon.svelte
@@ -412,7 +412,7 @@
                   <img class="h-6 inline-block mr-1" src={res.image} alt={res.label} />
                 </span>
               {/if}
-              {res.label}
+              {$t(res.label)}
             </span>
           </Checkbox>
         </div>
@@ -457,7 +457,7 @@
                           <img class="h-6 inline-block mr-1" src={res.image} alt={res.label} />
                         </span>
                       {/if}
-                      {res.label}
+                      {$t(res.label)}
                     </span>
                   </td>
                 </tr>

--- a/src/routes/calculator/_weapon.svelte
+++ b/src/routes/calculator/_weapon.svelte
@@ -477,7 +477,7 @@
                       <span class="w-6 inline-block">
                         <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={item.name} />
                       </span>
-                      {item.name}
+                      {$t(item.name)}
                     </span>
                   </td>
                 </tr>

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -479,7 +479,7 @@
           <p class="flex-1 text-gray-400"># {i + 1}</p>
           <Button on:click={() => askDeleteTodo(i)} size="sm" className="px-2">
             <Icon path={mdiClose} color="white" size={0.8} />
-            Delete
+            {$t('todo.delete.delete')}
           </Button>
         </div>
       </div>

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -313,7 +313,7 @@
                     <span class="w-6 inline-block">
                       <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={itemList[id].name} />
                     </span>
-                    {itemList[id].name}
+                    {$t(itemList[id].name)}
                   </span>
                 </td>
               </tr>
@@ -349,7 +349,7 @@
                         <span class="w-6 inline-block">
                           <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={itemList[id].name} />
                         </span>
-                        {itemGroup[id].name}
+                        {$t(itemGroup[id].name)}
                       </span>
                     </td>
                   </tr>
@@ -384,7 +384,7 @@
                 <span class="w-6 inline-block">
                   <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={itemList[id].name} />
                 </span>
-                {itemList[id].name}
+                {$t(itemList[id].name)}
               </span>
               {#if id === 'mora'}
                 <Button size="sm" disabled={amount === 0 && !adding} on:click={() => decrease(id, 1000)}>
@@ -422,7 +422,7 @@
               alt={todo.weapon ? todo.weapon.name : `Weapon Level ${todo.level.from}-${todo.level.to}`}
             />
             <div class="flex-1">
-              <p class="font-bold">{todo.weapon ? todo.weapon.name : 'Weapon'}</p>
+              <p class="font-bold">{todo.weapon ? $t(todo.weapon.name) : 'Weapon'}</p>
               <p class="text-gray-500">Level {`${todo.level.from}-${todo.level.to}`}</p>
             </div>
           {:else if todo.type === 'character'}
@@ -432,7 +432,7 @@
               alt={todo.character ? todo.character.name : `Character Level ${todo.level.from}-${todo.level.to}`}
             />
             <div class="flex-1">
-              <p class="font-bold">{todo.character ? todo.character.name : 'Character'}</p>
+              <p class="font-bold">{todo.character ? $t(todo.character.name) : 'Character'}</p>
               <p class="text-gray-500">Level {`${todo.level.from}-${todo.level.to}`}</p>
             </div>
           {:else if todo.type === 'item'}
@@ -469,7 +469,7 @@
                   <span class="w-6 inline-block">
                     <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={itemList[id].name} />
                   </span>
-                  {itemList[id].name}
+                  {$t(itemList[id].name)}
                 </span>
               </td>
             </tr>


### PR DESCRIPTION
## Description

The following items are i18n-compatible.

TodoDeleteModal

<img width="326" alt="image" src="https://user-images.githubusercontent.com/6679870/199720363-59d885ac-7fcb-49f4-a84e-c7430060623b.png">


Resource name in the Weapon section of the Calculator
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/6679870/199720581-eb346b9f-4b4c-4e7d-98ea-d7b0d3e2783f.png">


Resource name in the Character section of the Calculator
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/6679870/199720637-ef4d89eb-c385-446d-8bde-e0f9bd90fbe5.png">

Todo resource names and Delete label
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/6679870/199721040-9921b340-caac-48d6-9f0c-001e54c4d779.png">



