### PR TITLE
Update Raiden Shogun build

### DIFF
--- a/src/data/build.js
+++ b/src/data/build.js
@@ -1687,6 +1687,9 @@ export const builds = {
             refine: [5],
           },
           {
+            id: 'skyward_spine'
+          },
+          {
             id: 'vortex_vanquisher',
           },
           {


### PR DESCRIPTION
add missing Skyward Spine in weapons ranking

fixes #367