### PR TITLE
Use name instead of number to clarify Security Option

### DIFF
--- a/src/routes/wish/import.svelte
+++ b/src/routes/wish/import.svelte
@@ -94,12 +94,12 @@
     },
   };
 
-  let powershellScript = `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://gist.githubusercontent.com/MadeBaruna/1d75c1d37d19eca71591ec8a31178235/raw/649a9e3a4e88f3bffdd0fe6dd8eeed23737b15da/getlink.ps1'))} global"`;
-  let powershellScriptChina = `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://gist.githubusercontent.com/MadeBaruna/1d75c1d37d19eca71591ec8a31178235/raw/649a9e3a4e88f3bffdd0fe6dd8eeed23737b15da/getlink.ps1'))} china"`;
+  let powershellScript = `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://gist.githubusercontent.com/MadeBaruna/1d75c1d37d19eca71591ec8a31178235/raw/649a9e3a4e88f3bffdd0fe6dd8eeed23737b15da/getlink.ps1'))} global"`;
+  let powershellScriptChina = `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://gist.githubusercontent.com/MadeBaruna/1d75c1d37d19eca71591ec8a31178235/raw/649a9e3a4e88f3bffdd0fe6dd8eeed23737b15da/getlink.ps1'))} china"`;
   let powershellScriptSource = 'https://gist.github.com/MadeBaruna/1d75c1d37d19eca71591ec8a31178235';
   let powershellScriptAlt = `iex('Write-Host "Copy the wish history table!";while(1) { $c = Get-Clipboard -TextFormatType Html; if ($c -match "^SourceURL:https:/.+log") { break; }; for($i=5; $i -gt 0; $i--) { Write-Host "\`rChecking in $i" -NoNewline; Sleep 1; }; }; Write-Host " OK"; $m=(((Get-Clipboard -TextFormatType Html) | Select-String "(https:/.+log)").Matches[0].Value);$m; Set-Clipboard -Value $m;')`;
   let powershellScriptAlt2 =
-    "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://gist.githubusercontent.com/MadeBaruna/bf36bad751dc9221067ca1e31ab08255/raw/cb73a9f46f08fad6f27581ebb1a6249ba086af13/read.ps1'))";
+    "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; iex ((New-Object System.Net.WebClient).DownloadString('https://gist.githubusercontent.com/MadeBaruna/bf36bad751dc9221067ca1e31ab08255/raw/cb73a9f46f08fad6f27581ebb1a6249ba086af13/read.ps1'))";
   let copiedScript = false;
   let news = '';
   let showAdvancedOptions = false;


### PR DESCRIPTION
## What and Why

This change allows for easier auditing by those not familiar with Powershell.

It replaces the `-bor 3072` flag with ` [System.Net.SecurityProtocolType]::Tls12` which are equivalent. However, the TLS12 is both easier to read and for powershell newbies/non-programmers it's easier to find the documentation.

## Info:
[SecurityProtocolType name-to-number mapping](https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0). ie `3072` is equivalent to `Tls12`

[Docs on SecurityPointManager](https://learn.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.securityprotocol?view=net-7.0&redirectedfrom=MSDN#System_Net_ServicePointManager_SecurityProtocol)