### PR TITLE
Update compareLocalSave(): ignore sync conflict if only locale present

### DIFF
--- a/src/components/DataSync.svelte
+++ b/src/components/DataSync.svelte
@@ -201,8 +201,12 @@
       const localSave = await getLocalSaveJson();
       const localSize = new Blob([localSave]).size / 1000;
 
+      const negligibleKeys = ['converted', 'locale'];
+      const localSaveKeys = Object.keys(JSON.parse(localSave));
+      const isLocalSaveNegligible = localSaveKeys.every(key => negligibleKeys.includes(key));
+
       const remoteTime = dayjs(data[UPDATE_TIME_KEY]);
-      if ($updateTime !== null && remoteTime.diff($updateTime) !== 0) {
+      if ($updateTime !== null && !isLocalSaveNegligible && remoteTime.diff($updateTime) !== 0) {
         console.log('DRIVE SYNC CONFLICT!');
         openModal(
           SyncConflictModal,


### PR DESCRIPTION
Problem: there's always a Google Drive sync conflict modal opening when connecting because of the user's locale being saved from the start

Solution implemented: if the local save only consists of the user's locale, it's not considered as a sync conflict.