### PR TITLE
FIXED: Wish history API URL is changed

### DIFF
--- a/src/components/WishImportModal.svelte
+++ b/src/components/WishImportModal.svelte
@@ -167,7 +167,7 @@
     url.searchParams.append('lang', 'en-us');
     url.hash = '';
     url.host = 'hk4e-api-os.mihoyo.com';
-    url.pathname = 'event/gacha_info/api/getGachaLog';
+    url.pathname = 'gacha_info/api/getGachaLog';
 
     currentBanner = type.name;
 

--- a/src/routes/wish/import.svelte
+++ b/src/routes/wish/import.svelte
@@ -237,7 +237,7 @@
     url.searchParams.append('lang', 'en-us');
     url.hash = '';
     url.host = 'hk4e-api-os.hoyoverse.com';
-    url.pathname = 'event/gacha_info/api/getGachaLog';
+    url.pathname = 'gacha_info/api/getGachaLog';
 
     if ($server === 'China') {
       url.host = 'hk4e-api.mihoyo.com';


### PR DESCRIPTION
Hoyoverse wish API URL is changed from event/gacha_info/api/getGachaLog -> gacha_info/api/getGachaLog