### PR TITLE
Improvements to todo functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn-error.log
 .svelte-kit
 /build
 .env
+.vscode

--- a/src/components/TodoEditCharacterModal.svelte
+++ b/src/components/TodoEditCharacterModal.svelte
@@ -1,0 +1,516 @@
+<script>
+  import { t } from 'svelte-i18n';
+
+  import { onMount } from 'svelte';
+  import { fade } from 'svelte/transition';
+  import { mdiCheckCircleOutline, mdiClose, mdiInformationOutline } from '@mdi/js';
+
+  import Input from './Input.svelte';
+  import AscensionSelector from './AscensionSelector.svelte';
+  import Checkbox from './Checkbox.svelte';
+  import Check from './Check.svelte';
+  import Button from './Button.svelte';
+  import Icon from './Icon.svelte';
+
+  import { characterExp } from '../data/characterExp';
+  import { characters, isTravelerId, minCharacterLevel, maxCharacterLevel } from '../data/characters';
+  import { talent } from '../data/talent';
+  import { updateTodo } from '../stores/todo';
+  import { itemList } from '../data/itemList';
+  import * as calculator from '../functions/resourceCalculator';
+
+  export let todo;
+  export let todoIndex;
+  export let cancel;
+
+  let selectableExpMaterials = [
+    {
+      selected: true,
+      disabled: false,
+      ...itemList.heros_wit
+    },
+    {
+      selected: true,
+      disabled: false,
+      ...itemList.adventurers_experience
+    },
+    {
+      selected: true,
+      disabled: false,
+      ...itemList.wanderes_advice
+    },
+  ];
+
+  let updatedTodo = false;
+
+  let withAscension = todo.ascension != null;
+  let withTalent = todo.talentLevel != null;
+
+  let character = todo.character;
+
+  let currentLevel = todo.level.from;
+  let currentExp = todo.exp;
+  let currentExpAsNumber = 0;
+  let intendedLevel = todo.level.to;
+  
+  let currentAscension = withAscension ? todo.ascension.from : 0;
+  let intendedAscension = withAscension ? todo.ascension.to : 0;
+
+  let currentTalentLevel = withTalent ? todo.talentLevel.from : {first: 1, second: 1, third: 1};
+  let intendedTalentLevel = withTalent ? todo.talentLevel.to : {first: 1, second: 1, third: 1};
+
+  let minAscension = 0;
+  let minIntendedAscension = 0;
+  let maxTalentLevel = 1;
+
+  let levelMaterials = [];
+  let ascensionAndTalentMaterials = [];
+  let unknownList = [];
+  let moraNeeded = 0;
+  let expWasted = 0;
+  let calculated = false;
+
+  let numberFormat = Intl.NumberFormat();
+
+  $: currentAscension = calculator.calculateMinimumAscension(currentLevel);
+  $: intendedAscension = calculator.calculateMinimumAscension(intendedLevel);
+  $: currentExpAsNumber = currentExp == null ? 0 : currentExp;
+  $: intendedAscension, updateMaxTalentLevel();
+  $: withAscension, checkWithTalent();
+
+  $: canCalculate =
+    (withAscension ? character !== null : true) &&
+    intendedLevel >= currentLevel &&
+    intendedAscension >= currentAscension &&
+    currentLevel !== null &&
+    currentLevel >= minCharacterLevel &&
+    currentLevel <= maxCharacterLevel &&
+    intendedLevel !== null &&
+    intendedLevel >= minCharacterLevel &&
+    intendedLevel <= maxCharacterLevel;
+
+  function checkWithTalent() {
+    if (!withAscension) {
+      withTalent = false;
+    }
+  }
+
+  function updateMaxTalentLevel() {
+    switch (intendedAscension) {
+      case 6:
+        maxTalentLevel = 10;
+        break;
+      case 5:
+        maxTalentLevel = 8;
+        break;
+      case 4:
+        maxTalentLevel = 6;
+        break;
+      case 3:
+        maxTalentLevel = 4;
+        break;
+      case 2:
+        maxTalentLevel = 2;
+        break;
+    }
+
+    currentTalentLevel = {
+      first: Math.min(currentTalentLevel.first, maxTalentLevel),
+      second: Math.min(currentTalentLevel.second, maxTalentLevel),
+      third: Math.min(currentTalentLevel.third, maxTalentLevel),
+    };
+  }
+
+  function onChange() {
+    calculated = false;
+  }
+
+  function calculate() {
+    unknownList = [];
+    moraNeeded = 0;
+
+    const targetExp = characterExp[intendedLevel - 1] - (characterExp[currentLevel - 1] + currentExp);
+    
+    const expMaterials = selectableExpMaterials
+      .filter(r => r.selected)
+      .sort((a, b) => b.exp - a.exp);
+
+    const levelResult = calculator.calculateCharacterLevelMaterials(targetExp, expMaterials);
+    levelMaterials = levelResult.materialsUsed;
+    expWasted = levelResult.expWasted;
+    moraNeeded += levelResult.mora;
+
+    ascensionAndTalentMaterials = null;
+    if (withAscension) {
+      let ascensionAndTalentMatsMap = {};
+      let ascensionResult = calculator.calculateCharacterAscensionMaterials(character, currentAscension, intendedAscension);
+      ascensionAndTalentMatsMap = ascensionResult.materials;
+      unknownList.push(...ascensionResult.unknownList);
+      moraNeeded += ascensionResult.mora;
+
+      if (withTalent) {
+        let talentResult = {};
+
+        if (isTravelerId(character.id)) {
+          talentResult = calculator.calculateTalentMaterialsTraveler(character, currentTalentLevel, intendedTalentLevel);
+        } else {
+          talentResult = calculator.calculateTalentMaterials(character, currentTalentLevel, intendedTalentLevel);
+        }
+
+        moraNeeded += talentResult.mora;
+        
+        const talentOrderOffset = 1000;
+        for (const [id, mat] of Object.entries(talentResult.items)) {
+          if (ascensionAndTalentMatsMap[id]) {
+            ascensionAndTalentMatsMap[id].amount += mat.amount;
+          } else {
+            ascensionAndTalentMatsMap[id] = mat;
+            ascensionAndTalentMatsMap[id].order += talentOrderOffset;
+          }
+        }
+      }
+
+      ascensionAndTalentMaterials = Object.entries(ascensionAndTalentMatsMap).sort((a, b) => a[1].order - b[1].order);
+    }
+
+    calculated = true;
+  }
+
+  function confirmChanges() {
+    let serializedLevelMats = levelMaterials.reduce((sum, item, i) => {
+      if (item.amount > 0) {
+        sum[item.material.id] = item.amount;
+      }
+
+      return sum;
+    }, {});
+
+    let serializedAscensionMats = [];
+    if (ascensionAndTalentMaterials != null) {
+      serializedAscensionMats = ascensionAndTalentMaterials.reduce((sum, value, i) => {
+        let stack = value[1];
+        if (stack.amount > 0) {
+          sum[stack.item.id] = stack.amount;
+        }
+  
+        return sum;
+      }, {});
+    }
+
+    updateTodo({
+      formatVersion: 2,
+      type: 'character',
+      character: withAscension ? character : null,
+      level: { from: currentLevel, to: intendedLevel },
+      ascension: withAscension ? { from: currentAscension, to: intendedAscension } : null,
+      exp: currentExp,
+      talentLevel: withTalent ? { from: currentTalentLevel, to: intendedTalentLevel } : null,
+      resources: {
+        mora: moraNeeded,
+        ...serializedLevelMats,
+        ...serializedAscensionMats,
+      },
+      original: {
+        mora: moraNeeded,
+        ...serializedLevelMats,
+        ...serializedAscensionMats,
+      },
+    },
+    todoIndex
+    );
+
+    updatedTodo = true;
+    setTimeout(() => {
+      updatedTodo = false;
+    }, 2000);
+  }
+</script>
+
+<div class="{withAscension ? "modal-ascension" : "modal-no-ascension"} h-full">
+  <div class="items-center">
+    <div>
+      <!-- Character title -->
+      <div class="flex items-center mb-4 p-3 rounded-md text-white bg-item">
+        <img
+          class="h-8 inline-block mr-2"
+          src={`/images/characters/${character ? character.id : 'characters'}.png`}
+          alt={character ? character.name : `Unknown Character`} 
+        />
+        <div class="flex-1">
+          <p class="font-bold">{character ? $t(character.name) : 'Character'}</p>
+        </div>
+      </div>
+      <p class="text-white text-center lg:text-left mb-1">{$t('calculator.character.resource')}</p>
+      {#each selectableExpMaterials as item}
+        <div class="mb-1">
+          <Checkbox disabled={item.disabled} bind:checked={item.selected} on:change={onChange}>
+            <span class="text-white">
+              <span class="w-6 inline-block">
+                <img class="h-6 inline-block mr-1" src={`/images/items/${item.id}.png`} alt={item.name} />
+              </span>
+              {$t(item.name)}
+            </span>
+          </Checkbox>
+        </div>
+      {/each}
+      <div>
+        <p class="text-white text-center mt-3 mb-2">{$t('calculator.character.current')}</p>
+        <Input
+          className="mb-2"
+          on:change={onChange}
+          type="number"
+          min={minCharacterLevel}
+          max={maxCharacterLevel}
+          bind:value={currentLevel}
+          placeholder={$t('calculator.character.inputCurrentLevel')}
+        />
+        <Input
+          className="mb-2"
+          on:change={onChange}
+          type="number"
+          min={0}
+          bind:value={currentExp}
+          placeholder={$t('calculator.character.inputCurrentExp')}
+        />
+        {#if withAscension}
+          <AscensionSelector min={minAscension} bind:value={currentAscension} on:change={onChange} />
+        {/if}
+      </div>
+      <div>
+        <p class="text-white text-center mt-3 mb-2">{$t('calculator.character.intended')}</p>
+        <Input
+          className="mb-2"
+          on:change={onChange}
+          type="number"
+          min={currentLevel}
+          max={maxCharacterLevel}
+          bind:value={intendedLevel}
+          placeholder={$t('calculator.character.inputIntendedLevel')}
+        />
+        {#if withAscension}
+          <AscensionSelector
+            min={Math.max(currentAscension, minIntendedAscension)}
+            bind:value={intendedAscension}
+            on:change={onChange}
+          />
+        {/if}
+      </div>
+    </div>
+  </div>
+  <!-- 
+    Since this column is only relevant for todos with ascension enabled (i.e. a specific character todo),
+    this column will have no content when displaying no-ascension/generic character todo items. 
+    The issue is it will still take up space since this div is a grid item.
+    Wrapping it in an if block allows for it to disappear and free up space when it's not needed.
+  -->
+  {#if withAscension}
+    <div class="flex flex-col">
+      <div class="mt-4">
+        <Check on:change={onChange} bind:checked={withTalent}>{$t('calculator.character.calculateTalent')}</Check>
+        {#if withTalent}
+          <p class="text-white text-center mt-3">{$t('calculator.character.inputTalentLevel')}</p>
+          <p class="text-green-300 text-center">{$t('calculator.character.inputTalentNotice')}</p>
+          <div class="grid grid-cols-3 gap-2 mt-2">
+            <Input
+              on:change={onChange}
+              type="number"
+              min={1}
+              max={maxTalentLevel}
+              bind:value={currentTalentLevel.first}
+              placeholder={$t('calculator.character.talent.0')}
+            />
+            <Input
+              on:change={onChange}
+              type="number"
+              min={1}
+              max={maxTalentLevel}
+              bind:value={currentTalentLevel.second}
+              placeholder={$t('calculator.character.talent.1')}
+            />
+            <Input
+              on:change={onChange}
+              type="number"
+              min={1}
+              max={maxTalentLevel}
+              bind:value={currentTalentLevel.third}
+              placeholder={$t('calculator.character.talent.2')}
+            />
+          </div>
+          <p class="text-white text-center mt-3">{$t('calculator.character.talentToLevel')}</p>
+          <div class="grid grid-cols-3 gap-2 mt-2">
+            <Input
+              on:change={onChange}
+              type="number"
+              min={currentTalentLevel.first}
+              max={maxTalentLevel}
+              bind:value={intendedTalentLevel.first}
+              placeholder={$t('calculator.character.talent.0')}
+            />
+            <Input
+              on:change={onChange}
+              type="number"
+              min={currentTalentLevel.second}
+              max={maxTalentLevel}
+              bind:value={intendedTalentLevel.second}
+              placeholder={$t('calculator.character.talent.1')}
+            />
+            <Input
+              on:change={onChange}
+              type="number"
+              min={currentTalentLevel.third}
+              max={maxTalentLevel}
+              bind:value={intendedTalentLevel.third}
+              placeholder={$t('calculator.character.talent.2')}
+            />
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+  <div class="flex flex-col h-full md:col-span-2 xl:col-span-1">
+    <Button disabled={!canCalculate} className="block w-full md:w-auto" on:click={calculate}>
+      {$t('calculator.character.calculate')}
+    </Button>
+    {#if calculated}
+      {#if Object.keys(unknownList).length > 0}
+        <div class="border-2 border-red-400 rounded-xl mt-2 p-4 md:inline-block">
+          <p class="font-bold flex items-center text-red-400">
+            <Icon className="mr-1 mb-1" path={mdiInformationOutline} />
+            {$t('calculator.character.talent.2')}
+          </p>
+          {#each Object.entries(unknownList) as [title, values]}
+            <p class="text-red-400">{$t('calculator.character.ascensionLevel')} {Number(title) + 1}</p>
+            <ul>
+              {#each values as val}
+                <li class="pl-4 text-red-400">- {val}</li>
+              {/each}
+            </ul>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+    <div transition:fade={{ duration: 100 }} class="wrap-table bg-background rounded-xl p-4 mt-2 block md:inline-block">
+      <table>
+        {#if calculated}
+          <tr>
+            <td class="text-right border-b border-gray-700 py-1">
+              <span class="text-white mr-2 whitespace-nowrap">
+                {numberFormat.format(moraNeeded)}
+                <Icon size={0.5} path={mdiClose} />
+              </span>
+            </td>
+            <td class="border-b border-gray-700 py-1">
+              <span class="text-white">
+                <span class="w-6 inline-block">
+                  <img class="h-6 inline-block mr-1" src="/images/mora.png" alt="Mora" />
+                </span>
+                {$t('calculator.character.mora')}
+              </span>
+            </td>
+          </tr>
+          {#each levelMaterials as stack, i}
+          <tr>
+            <td class="text-right border-b border-gray-700 py-1">
+              <span class="text-white mr-2 whitespace-nowrap">
+                  {stack.amount}
+                  <Icon size={0.5} path={mdiClose} />
+                </span>
+              </td>
+              <td class="border-b border-gray-700 py-1">
+                <span class="text-white">
+                  <span class="w-6 inline-block">
+                    <img class="h-6 inline-block mr-1" src={`/images/items/${stack.material.id}.png`} alt={stack.material.name} />
+                  </span>
+                  {$t(stack.material.name)}
+                </span>
+              </td>
+            </tr>
+          {/each}
+          {#if ascensionAndTalentMaterials != null}
+            {#each ascensionAndTalentMaterials as [id, stack]}
+              {#if stack.amount > 0}
+              <tr>
+                  <td class="text-right border-b border-gray-700 py-1">
+                    <span class="text-white mr-2 whitespace-nowrap">
+                      {stack.amount}
+                      <Icon size={0.5} path={mdiClose} />
+                    </span>
+                  </td>
+                  <td class="border-b border-gray-700 py-1">
+                    <span class="text-white">
+                      <span class="w-6 inline-block">
+                        <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={stack.item.name} />
+                      </span>
+                      {$t(stack.item.name)}
+                    </span>
+                  </td>
+                </tr>
+              {/if}
+              {/each}
+          {/if}
+          <tr>
+            <td />
+            <td class="text-red-400 py-1">{expWasted} {$t('calculator.character.expWasted')}</td>
+          </tr>
+        {/if}
+      </table>
+    </div>
+    <div class="flex gap-2">
+      <Button className="mt-2 w-min grow" on:click={cancel}>
+        {$t('todo.edit.cancel')}
+      </Button>
+      
+      <Button className="mt-2 grow" disabled={!calculated} on:click={updatedTodo ? () => {} : confirmChanges}>
+        {#if updatedTodo}
+          <span class="text-green-400" in:fade={{ duration: 100 }}>
+            <Icon path={mdiCheckCircleOutline} size={0.8} />
+            {$t('todo.edit.confirmed')}
+          </span>
+        {:else}
+          <span in:fade={{ duration: 100 }}>{$t('todo.edit.confirm')}</span>
+        {/if}
+      </Button>
+    </div>
+  </div>
+</div>
+
+<style lang="postcss">
+  .modal-ascension {
+    width: 80vw;
+    @apply bg-item;
+    @apply grid;
+    @apply grid-cols-1;
+    @apply md:grid-cols-2;
+    @apply xl:grid-cols-3; 
+    @apply gap-4;
+    @apply p-4;
+    @apply rounded-xl;
+  }
+
+  /* No-ascension todo items can comfortably fit in a more compact 2-column layout in desktop aspect ratios. */
+  .modal-no-ascension {
+    width: 80vw;
+    @apply bg-item;
+    @apply grid;
+    @apply grid-cols-1;
+    @apply md:grid-cols-2;
+    @apply gap-4;
+    @apply p-4;
+    @apply rounded-xl;
+
+    @media screen(lg) {
+      /* 
+      On wider displays, the no-ascension modal is only two columns wide, so less horizontal space is needed.
+      Making it any wider makes each column look too streched out.
+      */
+      width: 50vw;
+    }
+  }
+
+  .wrap-table {
+    overflow: hidden scroll;
+    flex-basis: 20vh;
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+</style>

--- a/src/components/TodoEditCharacterModal.svelte
+++ b/src/components/TodoEditCharacterModal.svelte
@@ -1,7 +1,6 @@
 <script>
   import { t } from 'svelte-i18n';
 
-  import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { mdiCheckCircleOutline, mdiClose, mdiInformationOutline } from '@mdi/js';
 
@@ -14,7 +13,6 @@
 
   import { characterExp } from '../data/characterExp';
   import { characters, isTravelerId, minCharacterLevel, maxCharacterLevel } from '../data/characters';
-  import { talent } from '../data/talent';
   import { updateTodo } from '../stores/todo';
   import { itemList } from '../data/itemList';
   import * as calculator from '../functions/resourceCalculator';

--- a/src/components/TodoEditWeaponModal.svelte
+++ b/src/components/TodoEditWeaponModal.svelte
@@ -4,10 +4,8 @@
   import { fade } from 'svelte/transition';
   import { mdiStar, mdiClose, mdiInformationOutline, mdiCheckCircleOutline } from '@mdi/js';
 
-  import Select from './Select.svelte';
   import Input from './Input.svelte';
   import AscensionSelector from './AscensionSelector.svelte';
-  import WeaponSelect from './WeaponSelect.svelte';
   import Checkbox from './Checkbox.svelte';
   import Check from './Check.svelte';
   import Button from './Button.svelte';
@@ -200,66 +198,65 @@
   }
 </script>
 
-<div class="modal bg-item rounded-xl p-4">
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-4">
-    <div>
-      <!-- Todo item banner -->
-      <div class="flex items-center mb-4 p-3 rounded-md text-white bg-item">
-        <img
-          class="h-8 inline-block mr-2"
-          src={`/images/weapons/${todo.weapon ? todo.weapon.id : 'any_weapon_1'}.png`}
-          alt={todo.weapon ? todo.weapon.name : `Unknown Weapon`} />
-        <div class="flex-1">
-          <p class="font-bold">{todo.weapon ? $t(todo.weapon.name) : 'Weapon'}</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p class="text-white text-center mt-3 mb-2">{$t('calculator.weapon.current')}</p>
-          <Input
-            className="mb-2"
-            on:change={onChange}
-            type="number"
-            min={1}
-            max={80}
-            bind:value={currentLevel}
-            placeholder={$t('calculator.weapon.inputCurrentLevel')}
-          />
-          <Input
-            className="mb-2"
-            on:change={onChange}
-            type="number"
-            min={0}
-            bind:value={currentExp}
-            placeholder={$t('calculator.weapon.inputCurrentExp')}
-          />
-          {#if withAscension}
-            <AscensionSelector min={minAscension} bind:value={currentAscension} on:change={onChange} />
-          {/if}
-        </div>
-        <div>
-          <p class="text-white text-center mt-3 mb-2">{$t('calculator.weapon.intended')}</p>
-          <Input
-            className="mb-2"
-            on:change={onChange}
-            type="number"
-            min={currentLevel}
-            max={80}
-            bind:value={intendedLevel}
-            placeholder={$t('calculator.weapon.inputIntendedLevel')}
-          />
-          {#if withAscension}
-            <AscensionSelector
-              min={Math.max(currentAscension, minIntendedAscension)}
-              bind:value={intendedAscension}
-              on:change={onChange}
-            />
-          {/if}
-        </div>
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-4 bg-item rounded-xl px-4 py-8">
+  <div>
+    <!-- Todo item banner -->
+    <div class="flex items-center mb-4 p-3 rounded-md text-white bg-item">
+      <img
+        class="h-8 inline-block mr-2"
+        src={`/images/weapons/${todo.weapon ? todo.weapon.id : 'any_weapon_1'}.png`}
+        alt={todo.weapon ? todo.weapon.name : `Unknown Weapon`} />
+      <div class="flex-1">
+        <p class="font-bold">{todo.weapon ? $t(todo.weapon.name) : 'Weapon'}</p>
       </div>
     </div>
-    <div class="flex flex-col pl-1">
-      <p class="text-white text-center md:text-left mb-1">{$t('calculator.weapon.resource')}</p>
+    <div>
+      <div>
+        <p class="text-white text-center mt-3 mb-2">{$t('calculator.weapon.current')}</p>
+        <Input
+          className="mb-2"
+          on:change={onChange}
+          type="number"
+          min={1}
+          max={80}
+          bind:value={currentLevel}
+          placeholder={$t('calculator.weapon.inputCurrentLevel')}
+        />
+        <Input
+          className="mb-2"
+          on:change={onChange}
+          type="number"
+          min={0}
+          bind:value={currentExp}
+          placeholder={$t('calculator.weapon.inputCurrentExp')}
+        />
+        {#if withAscension}
+          <AscensionSelector min={minAscension} bind:value={currentAscension} on:change={onChange} />
+        {/if}
+      </div>
+      <div>
+        <p class="text-white text-center mt-3 mb-2">{$t('calculator.weapon.intended')}</p>
+        <Input
+          className="mb-2"
+          on:change={onChange}
+          type="number"
+          min={currentLevel}
+          max={80}
+          bind:value={intendedLevel}
+          placeholder={$t('calculator.weapon.inputIntendedLevel')}
+        />
+        {#if withAscension}
+          <AscensionSelector
+            min={Math.max(currentAscension, minIntendedAscension)}
+            bind:value={intendedAscension}
+            on:change={onChange}
+          />
+        {/if}
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col pl-1">
+    <p class="text-white text-center md:text-left mb-1">{$t('calculator.weapon.resource')}</p>
       {#each selectableExpItems as item}
         <div class="mb-1">
           <Checkbox disabled={item.disabled} bind:checked={item.selected} on:change={onChange}>
@@ -294,77 +291,76 @@
             {/each}
           </div>
         {/if}
-          <div transition:fade={{ duration: 100 }} class="wrap-table bg-background rounded-xl p-4 mt-2 block md:inline-block">
-            <table>
+      {/if}
+      <div transition:fade={{ duration: 100 }} class="wrap-table bg-background rounded-xl p-4 mt-2 block md:inline-block">
+        <table>
+          {#if calculated}
+            <tr>
+              <td class="text-right border-b border-gray-700 py-1">
+                <span class="text-white mr-2 whitespace-nowrap">
+                  {numberFormat.format(moraNeeded)}
+                  <Icon size={0.5} path={mdiClose} />
+                </span>
+              </td>
+              <td class="border-b border-gray-700 py-1">
+                <span class="text-white">
+                  <span class="w-6 inline-block">
+                    <img class="h-6 inline-block mr-1" src="/images/mora.png" alt="Mora" />
+                  </span>
+                  {$t('calculator.weapon.mora')}
+                </span>
+              </td>
+            </tr>
+            {#each levelMaterials as stack, i}
               <tr>
                 <td class="text-right border-b border-gray-700 py-1">
                   <span class="text-white mr-2 whitespace-nowrap">
-                    {numberFormat.format(moraNeeded)}
+                    {stack.amount}
                     <Icon size={0.5} path={mdiClose} />
                   </span>
                 </td>
                 <td class="border-b border-gray-700 py-1">
                   <span class="text-white">
                     <span class="w-6 inline-block">
-                      <img class="h-6 inline-block mr-1" src="/images/mora.png" alt="Mora" />
+                      <img class="h-6 inline-block mr-1" src={`/images/items/${stack.material.id}.png`} alt={stack.material.name} />
                     </span>
-                    {$t('calculator.weapon.mora')}
+                    {$t(stack.material.name)}
                   </span>
                 </td>
               </tr>
-              {#each levelMaterials as stack, i}
-                <tr>
-                  <td class="text-right border-b border-gray-700 py-1">
-                    <span class="text-white mr-2 whitespace-nowrap">
-                      {stack.amount}
-                      <Icon size={0.5} path={mdiClose} />
-                    </span>
-                  </td>
-                  <td class="border-b border-gray-700 py-1">
-                    <span class="text-white">
-                      <span class="w-6 inline-block">
-                        <img class="h-6 inline-block mr-1" src={`/images/items/${stack.material.id}.png`} alt={stack.material.name} />
+            {/each}
+            {#if ascensionMaterials != null}
+              {#each ascensionMaterials as [id, stack]}
+                {#if stack.amount > 0}
+                  <tr>
+                    <td class="text-right border-b border-gray-700 py-1">
+                      <span class="text-white mr-2 whitespace-nowrap">
+                        {stack.amount}
+                        <Icon size={0.5} path={mdiClose} />
                       </span>
-                      {$t(stack.material.name)}
-                    </span>
-                  </td>
-                </tr>
+                    </td>
+                    <td class="border-b border-gray-700 py-1">
+                      <span class="text-white">
+                        <span class="w-6 inline-block">
+                          <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={stack.item.name} />
+                        </span>
+                        {$t(stack.item.name)}
+                      </span>
+                    </td>
+                  </tr>
+                {/if}
               {/each}
-              {#if ascensionMaterials != null}
-                {#each ascensionMaterials as [id, stack]}
-                  {#if stack.amount > 0}
-                    <tr>
-                      <td class="text-right border-b border-gray-700 py-1">
-                        <span class="text-white mr-2 whitespace-nowrap">
-                          {stack.amount}
-                          <Icon size={0.5} path={mdiClose} />
-                        </span>
-                      </td>
-                      <td class="border-b border-gray-700 py-1">
-                        <span class="text-white">
-                          <span class="w-6 inline-block">
-                            <img class="h-6 inline-block mr-1" src={`/images/items/${id}.png`} alt={stack.item.name} />
-                          </span>
-                          {$t(stack.item.name)}
-                        </span>
-                      </td>
-                    </tr>
-                  {/if}
-                {/each}
-              {/if}
-              {#if expWasted > 0}
-                <tr>
-                  <td />
-                  <td class="text-red-400 py-1">{expWasted} {$t('calculator.weapon.expWasted')}</td>
-                </tr>
-              {/if}
-            </table>
-          </div>
-        {:else}
-          <!-- Placeholder for calculation results. Also fills space so confirm and cancel buttons will always be at the bottom. -->
-          <div class="bg-background-secondary grow mt-2 rounded-xl"></div>
-        {/if}
-        <div class="flex gap-2">
+            {/if}
+            {#if expWasted > 0}
+              <tr>
+                <td />
+                <td class="text-red-400 py-1">{expWasted} {$t('calculator.weapon.expWasted')}</td>
+              </tr>
+            {/if}
+          {/if}
+        </table>
+      </div>
+      <div class="flex gap-2">
           <Button className="mt-2 w-min grow" on:click={cancel}>
             {$t('todo.edit.cancel')}
           </Button>
@@ -379,18 +375,11 @@
               <span in:fade={{ duration: 100 }}>{$t('todo.edit.confirm')}</span>
             {/if}
           </Button>
-        </div>
       </div>
     </div>
 </div>
 
 <style lang="postcss">
-  .modal {
-    @apply bg-item;
-    @apply px-4;
-    @apply py-8;
-  }
-
   .wrap-table {
     overflow: hidden scroll;
     flex-basis: 20vh;

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -1,5 +1,8 @@
 <script>
   export let title = '';
+  export let enabled = true;
+  export let style = '';
+
   let isHovered = false;
   let x;
   let y;
@@ -22,8 +25,8 @@
   <slot />
 </i>
 
-{#if isHovered}
-  <div style="top: {y}px; left: {x}px;" class="tooltip">{title}</div>
+{#if isHovered && enabled}
+  <div style="{style} top: {y}px; left: {x}px;" class="tooltip">{title}</div>
 {/if}
 
 <style lang="postcss">

--- a/src/data/characters.js
+++ b/src/data/characters.js
@@ -3,6 +3,19 @@ import { itemList } from './itemList';
 import { elements } from './elements';
 import { weapons } from './weapons';
 
+export const minCharacterLevel = 1;
+export const maxCharacterLevel = 90;
+export const minCharacterAscension = 0;
+export const maxCharacterAscension = 6;
+
+export function isTravelerId(id) {
+  return 
+  id === characters.traveler_anemo.id ||
+  id === characters.traveler_geo.id ||
+  id === characters.traveler_electro.id ||
+  id === characters.traveler_dendro.id;
+}
+
 export const characters = {
   albedo: {
     id: 'albedo',

--- a/src/data/itemList.js
+++ b/src/data/itemList.js
@@ -1,17 +1,20 @@
 export const itemList = {
   unknown: { id: 'unknown', name: 'unknown' },
   none: { id: 'none', name: 'none' },
-  mystic_enhancement_ore: { id: 'mystic_enhancement_ore', name: 'Mystic Enhancement Ore' },
-  fine_enhancement_ore: { id: 'fine_enhancement_ore', name: 'Fine Enhancement Ore' },
-  enhancement_ore: { id: 'enhancement_ore', name: 'Enhancement Ore' },
-  any_weapon_1: { id: 'any_weapon_1', name: '1 Star Weapon' },
-  any_weapon_2: { id: 'any_weapon_2', name: '2 Star Weapon' },
-  any_weapon_3: { id: 'any_weapon_3', name: '3 Star Weapon' },
+
   mora: { id: 'mora', name: 'Mora' },
-  heros_wit: { id: 'heros_wit', name: "Hero's Wit" },
-  adventurers_experience: { id: 'adventurers_experience', name: "Adventurer's Experience" },
-  wanderes_advice: { id: 'wanderes_advice', name: "Wanderer's Advice" },
   crown_of_insight: { id: 'crown_of_insight', name: 'Crown of Insight' },
+
+  mystic_enhancement_ore: { id: 'mystic_enhancement_ore', name: 'Mystic Enhancement Ore', exp: 10000 },
+  fine_enhancement_ore: { id: 'fine_enhancement_ore', name: 'Fine Enhancement Ore', exp: 2000 },
+  enhancement_ore: { id: 'enhancement_ore', name: 'Enhancement Ore', exp: 400 },
+  any_weapon_1: { id: 'any_weapon_1', name: '1 Star Weapon', exp: 600 },
+  any_weapon_2: { id: 'any_weapon_2', name: '2 Star Weapon', exp: 1200 },
+  any_weapon_3: { id: 'any_weapon_3', name: '3 Star Weapon', exp: 1800 },
+
+  heros_wit: { id: 'heros_wit', name: "Hero's Wit", exp: 20000},
+  adventurers_experience: { id: 'adventurers_experience', name: "Adventurer's Experience", exp: 5000 },
+  wanderes_advice: { id: 'wanderes_advice', name: "Wanderer's Advice", exp: 1000 },
 
   fetters_of_the_dandelion_gladiator: {
     id: 'fetters_of_the_dandelion_gladiator',

--- a/src/data/weaponExp.js
+++ b/src/data/weaponExp.js
@@ -1,4 +1,5 @@
 export const weaponExp = [
+  // Rarity 3
   [
       0,
       275,
@@ -91,6 +92,7 @@ export const weaponExp = [
       3727000,
       3988200
   ],
+  // Rarity 4
   [
       0,
       400,
@@ -183,6 +185,7 @@ export const weaponExp = [
       5646875,
       6042650
   ],
+  // Rarity 5
   [
       0,
       600,
@@ -276,3 +279,20 @@ export const weaponExp = [
       9064450
   ]
 ];
+
+/**
+ * Get the total EXP amount that corresponds to the level of a weapon.
+ * @param {number} level
+ * @param {number} exp
+ * @param {number} rarity
+ * @returns {number}
+ */
+export function getWeaponExp(level, exp, rarity) {
+  let rarityIndex = rarity - 3;
+  if (rarity > 2 && rarity < 6) {
+    return weaponExp[rarityIndex][level - 1] + exp;
+  }
+  else {
+    throw new RangeError("Can only retrieve EXP for weapons of rarity 3, 4, or 5");
+  }
+}

--- a/src/data/weapons.js
+++ b/src/data/weapons.js
@@ -20,3 +20,16 @@ export const weapons = {
     name: 'Catalyst',
   },
 };
+
+export const minWeaponLevel = 1;
+export const maxWeaponLevel = 90;
+export const minWeaponAscension = 0;
+export const maxWeaponAscension = 6;
+
+export let weaponRarityInfo = [
+  { label: '1 Star', value: 1 },
+  { label: '2 Star', value: 2 },
+  { label: '3 Star', value: 3 },
+  { label: '4 Star', value: 4 },
+  { label: '5 Star', value: 5 },
+];

--- a/src/functions/resourceCalculator.js
+++ b/src/functions/resourceCalculator.js
@@ -1,0 +1,153 @@
+function getSuffix(val) {
+  switch (val) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    case 4:
+      return 'th';
+  }
+}
+
+export function calculateMinimumAscension(level) {
+  if (level > 80) {
+    return 6;
+  } else if (level > 70) {
+    return 5;
+  } else if (level > 60) {
+    return 4;
+  } else if (level > 50) {
+    return 3;
+  } else if (level > 40) {
+    return 2;
+  } else if (level > 20) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+/**
+ * Heuristic for finding the amount of EXP materials needed to reach an amount of EXP.
+ * Material usage is not guaranteed to be optimal (i.e. least amount of EXP wasted possible).
+ * 
+ * @typedef {Object} LevelResult
+ * @property {ExpMaterialStack[]} materialsUsed
+ * @property {number} expWasted
+ * @property {number} mora
+ * 
+ * @typedef {Object} ExpMaterialStack
+ * @property {ExpMaterial} material
+ * @property {number} amount
+ * 
+ * @typedef {Object} ExpMaterial
+ * @property {number} exp
+ * 
+ * @param {number} remainingExp 
+ * @param {object[]} expMaterials 
+ * @param {object[]} materialsUsed 
+ * @param {number} materialIndex 
+ * 
+ * @returns {LevelResult} 
+ */
+function resolveExpMaterials(remainingExp, expMaterials, materialsUsed, materialIndex) {
+  if (remainingExp <= 0) {
+    return {materialsUsed: materialsUsed, expWasted: Math.abs(remainingExp)};
+  }
+  
+  const expMaterial = expMaterials[materialIndex];
+  const matExp = expMaterial.exp;
+  const amountNeeded = remainingExp / matExp;
+  const expMaterialIsLastMaterial = expMaterials[materialIndex + 1] == null;
+
+  // If exp material is last material in the array, resolve the remaining EXP with this material
+  // even if the EXP usage is not optimal.
+  if (expMaterialIsLastMaterial) {
+    const amountUsed = Math.ceil(amountNeeded);
+    remainingExp -= matExp * amountUsed;
+    materialsUsed.push({material: expMaterial, amount: amountUsed});
+    
+    return resolveExpMaterials(remainingExp, expMaterials, materialsUsed, materialIndex + 1);
+  }
+  else {
+    const amountUsed = Math.floor(amountNeeded);
+    
+    if (amountUsed > 0) {
+      remainingExp -= matExp * amountUsed;
+      materialsUsed.push({material: expMaterial, amount: amountUsed});
+    }
+    
+    return resolveExpMaterials(remainingExp, expMaterials, materialsUsed, materialIndex + 1);
+  }
+}
+
+/**
+ * Calculates what materials (including mora) are needed to reach an amount of level EXP for a weapon.
+ * 
+ * @param {number} exp
+ * @param {ExpMaterial[]} expMaterials
+ * @param {ExpMaterialStack[]} materialsUsed
+ * @param {number} materialIndex
+ * 
+ * @returns {LevelResult} 
+*/
+export function calculateWeaponLevelMaterials(exp, expMaterials) {
+  const result = resolveExpMaterials(exp, expMaterials, [], 0);
+  result.mora = Math.ceil(exp / 10 / 20) * 20;
+  return result;
+}
+
+/**
+ * @typedef WeaponAscensionResult
+ * @property {Object[]} materials
+ * @property {number} mora
+ * @property {Array} unknownList
+ * 
+ * @param {Object} weapon 
+ * @param {number} fromAscension 
+ * @param {number} toAscension
+ * 
+ * @returns {WeaponAscensionResult}
+ */
+export function calculateWeaponAscensionMaterials(weapon, fromAscension, toAscension) {
+  const result = weapon.ascension.slice(fromAscension, toAscension).reduce(
+    (sum, ascension, index) => {
+      const materials = sum.materials;
+      const unknownList = sum.unknownList;
+
+      if (ascension.mora === 0) {
+        if (unknownList[index + fromAscension] === undefined) {
+          unknownList[index + fromAscension] = ['Mora amount'];
+        }
+      }
+
+      sum.mora += ascension.mora;
+
+      for (const [i, stack] of ascension.items.entries()) {
+        if (stack.item.id === 'unknown') {
+          if (unknownList[index + fromAscension] === undefined) {
+            unknownList[index + fromAscension] = [];
+          }
+
+          unknownList[index + fromAscension].push(`${i + 1}${getSuffix(i + 1)} material`);
+        }
+
+        if (materials[stack.item.id] === undefined) {
+          materials[stack.item.id] = { item: stack.item, amount: 0, order: i };
+        }
+        materials[stack.item.id].amount += stack.amount;
+      }
+
+      return sum;
+    },
+    {
+      mora: 0,
+      materials: {},
+      unknownList: []
+    },
+  );
+
+  return result;
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -689,6 +689,13 @@
       "title": "Diese Aufgabe löschen?",
       "cancel": "Abbrechen",
       "delete": "Löschen"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -659,6 +659,13 @@
       "title": "Delete this todo?",
       "cancel": "Cancel",
       "delete": "Delete"
+    },
+    "edit": {
+      "title": "Edit todo item",
+      "cancel": "Cancel",
+      "confirm": "Confirm",
+      "confirmed": "Updated todo 👍",
+      "tooltipCannotEdit": "Cannot edit this item. Add this item from the calculator page again to enable editing."
     }
   },
   "timeline": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -689,6 +689,13 @@
       "title": "¿Borrar esta Tarea?",
       "cancel": "Cancelar",
       "delete": "Borrar"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -689,6 +689,13 @@
       "title": "Supprimer cette tâche ?",
       "cancel": "Annuler",
       "delete": "Supprimer"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -689,6 +689,13 @@
       "title": "Hapus todo ini?",
       "cancel": "Batal",
       "delete": "Hapus"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -689,6 +689,13 @@
       "title": "",
       "cancel": "",
       "delete": ""
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -689,6 +689,13 @@
       "title": "このTodoを削除しますか？",
       "cancel": "キャンセル",
       "delete": "削除する"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -689,6 +689,13 @@
       "title": "이 할일을 삭제할까요?",
       "cancel": "취소",
       "delete": "삭제"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -689,6 +689,13 @@
       "title": "Deletar esse afazer?",
       "cancel": "Cancelar",
       "delete": "Deletar"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -689,6 +689,13 @@
       "title": "Удалить этот список?",
       "cancel": "Отмена",
       "delete": "Удалить"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -689,6 +689,13 @@
       "title": "ลบรายการที่ต้องทำหรือไม่?",
       "cancel": "ยกเลิก",
       "delete": "ลบ"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -689,6 +689,13 @@
       "title": "",
       "cancel": "",
       "delete": ""
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/tw.json
+++ b/src/locales/tw.json
@@ -689,6 +689,13 @@
       "title": "刪除這項待辦事項？",
       "cancel": "取消",
       "delete": "刪除"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -689,6 +689,13 @@
       "title": "Xóa việc cần làm này?",
       "cancel": "Hủy",
       "delete": "Xóa"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -689,6 +689,13 @@
       "title": "删除这项规划？",
       "cancel": "取消",
       "delete": "删除"
+    },
+    "edit": {
+      "title": "",
+      "cancel": "",
+      "confirm": "",
+      "confirmed": "",
+      "tooltipCannotEdit": ""
     }
   },
   "timeline": {

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -12,6 +12,7 @@
   import Button from '../components/Button.svelte';
   import Tooltip from '../components/Tooltip.svelte';
   import TodoDeleteModal from '../components/TodoDeleteModal.svelte';
+  import TodoEditCharacterModal from '../components/TodoEditCharacterModal.svelte';
   import TodoEditWeaponModal from '../components/TodoEditWeaponModal.svelte';
   import { getCurrentDay } from '../stores/server';
   import { itemGroup } from '../data/itemGroup';
@@ -124,6 +125,61 @@
     }
 
     return false;
+  }
+
+  function openEditModal(index) {
+    if (index < 0 && index > $todos.length) return;
+
+    const todo = $todos[index];
+
+    // It would be nice if these styles could be put in a class, but svelte doesn't seem to recognize classes defined in this file
+    // when opening with `openModal`, so overriding each element's style here directly is the compromise. 
+    const modalOptions = {
+      closeButton: false,
+      styleWindow: { 
+        background: '#00000000',
+        width: 'max-content', 
+        margin: '0 auto',
+        // Aligns the content element vertically. Centering through flexbox is necessary since the final height of
+        // the content element is not known.
+        display: 'flex',
+        'align-items': 'center',
+      },
+      styleContent: { 
+        // svelte-simple-modal's content element has padding by default for some reason.
+        // This causes slight horizontal scroll when combined with the TodoEditCharacterModal div. 
+        // Disabling padding fixes the issue.
+        padding: "0",
+        'max-height': 'calc(100dvh - 4rem)',
+        margin: '0 auto'
+      }
+    };
+    
+    if (todo.type == "character") {
+      openModal(
+        TodoEditCharacterModal,
+        {
+          todo: todo,
+          todoIndex: index,
+          cancel: closeModal,
+        },
+        modalOptions
+      );   
+    }
+    else if (todo.type == "weapon") {
+      openModal(
+        TodoEditWeaponModal,
+        {
+          todo: todo,
+          todoIndex: index,
+          cancel: closeModal,
+        },
+        {
+          closeButton: false,
+          styleWindow: { background: '#00000000', width: '80vw'},
+        },
+      );
+    }
   }
 
   function decrease(key, val) {
@@ -288,26 +344,6 @@
     id = Math.random();
   }
 
-  function openEditModal(index) {
-    if (index < 0 && index > $todos.length) return;
-
-    const todo = $todos[index];
-    
-    if (todo.type == "weapon") {
-      openModal(
-        TodoEditWeaponModal,
-        {
-          todo: todo,
-          todoIndex: index,
-          cancel: closeModal,
-        },
-        {
-          closeButton: false,
-          styleWindow: { background: '#00000000', width: '80vw'},
-        },
-      );
-    }
-  }
 
   onMount(async () => {
     await tick();

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -343,34 +343,38 @@
       {:else}
         <p class="font-bold text-xl">{$t('todo.empty.0')}<br />{$t('todo.empty.1')}</p>
       {/if}
-      {#if Object.entries(todayOnlyItems).length > 0}
-        <div class="rounded-xl bg-background px-4 py-2 mb-2">
-          <p class="font-semibold mb-2 text-center">{$t('todo.farmableToday')}</p>
-          <table class="w-full">
-            {#each Object.entries(todayOnlyItems) as [id, amount]}
-              <tr class="today-only">
-                <td class="text-right border-b border-gray-700 py-1">
-                  <span class={`${amount === 0 ? 'line-through text-gray-600' : 'text-white'} mr-2 whitespace-nowrap`}>
-                    {numberFormat.format(amount)}
-                    <Icon size={0.5} path={mdiClose} /></span
-                  >
-                </td>
-                <td class="border-b border-gray-700 py-1">
-                  <span class={`${amount === 0 ? 'line-through text-gray-600' : 'text-white'} block`}>
-                    <span class="w-6 inline-block">
-                      <img
-                        class="h-6 inline-block mr-1"
-                        src={`/images/items/${itemList[id].id}.png`}
-                        alt={itemList[id].name}
-                      />
+      {#if isSunday}
+        <div class="text-white text-center">{$t('home.items.sunday')}</div> <br />
+      {:else}
+        {#if Object.entries(todayOnlyItems).length > 0}
+          <div class="rounded-xl bg-background px-4 py-2 mb-2">
+            <p class="font-semibold mb-2 text-center">{$t('todo.farmableToday')}</p>
+            <table class="w-full">
+              {#each Object.entries(todayOnlyItems) as [id, amount]}
+                <tr class="today-only">
+                  <td class="text-right border-b border-gray-700 py-1">
+                    <span class={`${amount === 0 ? 'line-through text-gray-600' : 'text-white'} mr-2 whitespace-nowrap`}>
+                      {numberFormat.format(amount)}
+                      <Icon size={0.5} path={mdiClose} /></span
+                    >
+                  </td>
+                  <td class="border-b border-gray-700 py-1">
+                    <span class={`${amount === 0 ? 'line-through text-gray-600' : 'text-white'} block`}>
+                      <span class="w-6 inline-block">
+                        <img
+                          class="h-6 inline-block mr-1"
+                          src={`/images/items/${itemList[id].id}.png`}
+                          alt={itemList[id].name}
+                        />
+                      </span>
+                      {$t(itemList[id].name)}
                     </span>
-                    {$t(itemList[id].name)}
-                  </span>
-                </td>
-              </tr>
-            {/each}
-          </table>
-        </div>
+                  </td>
+                </tr>
+              {/each}
+            </table>
+          </div>
+        {/if}
       {/if}
       {#if resin > 0}
         <div class="rounded-xl bg-background px-4 py-2 mb-2">

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -10,6 +10,7 @@
   import Masonry from '../components/Masonry.svelte';
   import Icon from '../components/Icon.svelte';
   import Button from '../components/Button.svelte';
+  import Tooltip from '../components/Tooltip.svelte';
   import TodoDeleteModal from '../components/TodoDeleteModal.svelte';
   import TodoEditWeaponModal from '../components/TodoEditWeaponModal.svelte';
   import { getCurrentDay } from '../stores/server';
@@ -546,17 +547,19 @@
         </table>
         <div class="flex mt-2 items-end">
           <p class="flex-1 text-gray-400"># {i + 1}</p>
-          <!-- Edit button -->
-          <Button 
-          on:click={() => openEditModal(i)}
-          disabled={!canEditTodo(i)} 
-          rounded={true} 
-          size="sm"
-          className="px-2 mx-2"
-          >
-          <Icon path={mdiPencilOutline} color="white" size={0.8}/>
-          Edit
-          </Button>
+          <Tooltip title={$t("todo.edit.tooltipCannotEdit")} style="max-width: 30ch;" enabled={!canEditTodo(i)}>
+            <!-- Edit button -->
+            <Button 
+            on:click={() => openEditModal(i)}
+            disabled={!canEditTodo(i)} 
+            rounded={true} 
+            size="sm"
+            className="px-2 mx-2"
+            >
+            <Icon path={mdiPencilOutline} color="white" size={0.8}/>
+            Edit
+            </Button>
+          </Tooltip>
           <!-- Delete button -->
           <Button on:click={() => askDeleteTodo(i)} size="sm" className="px-2">
             <Icon path={mdiClose} color="white" size={0.8} />

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -3,7 +3,7 @@
 
   import { getContext, onMount, tick } from 'svelte';
   import { slide } from 'svelte/transition';
-  import { mdiChevronDown, mdiChevronLeft, mdiChevronRight, mdiClose, mdiInformation, mdiLoading } from '@mdi/js';
+  import { mdiChevronDown, mdiChevronLeft, mdiChevronRight, mdiClose, mdiLoading, mdiPencilOutline } from '@mdi/js';
   import { todos, loading } from '../stores/todo';
   import { ar, wl } from '../stores/server';
   import { itemList as itemListData } from '../data/itemList';
@@ -11,6 +11,7 @@
   import Icon from '../components/Icon.svelte';
   import Button from '../components/Button.svelte';
   import TodoDeleteModal from '../components/TodoDeleteModal.svelte';
+  import TodoEditWeaponModal from '../components/TodoEditWeaponModal.svelte';
   import { getCurrentDay } from '../stores/server';
   import { itemGroup } from '../data/itemGroup';
   import { dropRates } from '../data/dropRates';
@@ -104,6 +105,24 @@
         styleWindow: { background: '#25294A', width: '400px' },
       },
     );
+  }
+
+  function canEditTodo(index) {
+    const todo = $todos[index];
+
+    if (todo.type == "character") {
+      if (todo.formatVersion != null && todo.formatVersion == 2) {
+        return true;
+      }
+    }
+
+    if (todo.type == "weapon") {
+      if (todo.formatVersion != null && todo.formatVersion == 2) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   function decrease(key, val) {
@@ -268,6 +287,27 @@
     id = Math.random();
   }
 
+  function openEditModal(index) {
+    if (index < 0 && index > $todos.length) return;
+
+    const todo = $todos[index];
+    
+    if (todo.type == "weapon") {
+      openModal(
+        TodoEditWeaponModal,
+        {
+          todo: todo,
+          todoIndex: index,
+          cancel: closeModal,
+        },
+        {
+          closeButton: false,
+          styleWindow: { background: '#00000000', width: '80vw'},
+        },
+      );
+    }
+  }
+
   onMount(async () => {
     await tick();
     id = Math.random();
@@ -288,6 +328,7 @@
     content="Genshin Impact Todo List to plan and track items and mora you need, you can also see resin approximation needed to farm the items!"
   />
 </svelte:head>
+
 <div class="lg:ml-64 pt-20 px-2 md:px-8 lg:pt-8">
   <Masonry stretchFirst={true} bind:refreshLayout bind:columnCount items={id}>
     <h1 class="font-display font-black text-3xl lg:text-left lg:text-5xl text-white">{$t('todo.title')}</h1>
@@ -459,9 +500,16 @@
               <p class="text-gray-500">Added from items page</p>
             </div>
           {/if}
-          <Button disabled={i === 0} on:click={() => reorder(i, -1)} rounded={false} size="sm" className="rounded-l-xl">
+          <Button 
+            disabled={i === 0} 
+            on:click={() => reorder(i, -1)} 
+            rounded={false} 
+            size="sm" 
+            className="rounded-l-xl"
+          >
             <Icon path={mdiChevronLeft} color="white" />
           </Button>
+
           <Button
             disabled={i === $todos.length - 1}
             on:click={() => reorder(i, 1)}
@@ -498,6 +546,18 @@
         </table>
         <div class="flex mt-2 items-end">
           <p class="flex-1 text-gray-400"># {i + 1}</p>
+          <!-- Edit button -->
+          <Button 
+          on:click={() => openEditModal(i)}
+          disabled={!canEditTodo(i)} 
+          rounded={true} 
+          size="sm"
+          className="px-2 mx-2"
+          >
+          <Icon path={mdiPencilOutline} color="white" size={0.8}/>
+          Edit
+          </Button>
+          <!-- Delete button -->
           <Button on:click={() => askDeleteTodo(i)} size="sm" className="px-2">
             <Icon path={mdiClose} color="white" size={0.8} />
             {$t('todo.delete.delete')}

--- a/src/routes/todo.svelte
+++ b/src/routes/todo.svelte
@@ -29,8 +29,8 @@
   let columnCount = 1;
   let numberFormat = Intl.NumberFormat();
   let adding = false;
-  let isSunday = false;
   let today = getCurrentDay();
+  let isSunday = today == "sunday";
   let summary = {};
   let todayOnlyItems = {};
   let resin = 0;

--- a/src/stores/todo.js
+++ b/src/stores/todo.js
@@ -38,3 +38,40 @@ export function addTodo(data) {
     }
   });
 }
+
+export function updateTodo(data, index) {
+  todos.update((value) => {
+    if (data.type === 'item') {
+      const itemsIndex = value.findIndex((e) => e.type === 'item');
+
+      if (itemsIndex > -1) {
+        const items = value[itemsIndex].resources;
+
+        if (items[data.item.id] !== undefined) {
+          items[data.item.id] += data.amount;
+        } else {
+          items[data.item.id] = data.amount;
+        }
+
+        value[itemsIndex] = {
+          type: 'item',
+          resources: items,
+          original: items,
+        };
+      } else {
+        const items = { [data.item.id]: data.amount };
+
+        value.push({
+          type: 'item',
+          resources: items,
+          original: items,
+        });
+      }
+
+      return value;
+    } else {
+      value[index] = data;
+      return value;
+    }
+  });
+}


### PR DESCRIPTION
1. Add functionality to edit character and weapon todo items after first calculation. This only works with newly added todo items since old todo items did not have enough information to construct an edit modal (like ascension and talents data).
[Demonstration of editing character todo with ascension](https://i.imgur.com/EIW3Iby.mp4)
[Demonstration of editing character todo without ascension](https://i.imgur.com/nHdnJfV.mp4)
[Demonstration of editing weapon todo](https://i.imgur.com/duMj35t.mp4)
[Demonstration of editing on mobile](https://i.imgur.com/jt4tDhj.mp4)
2. Weapon calculator now allows the user to disable Mystic Enhancement Ore as a calculatable exp material.
3. Todo route now informs the user when it's Sunday and all items are farmable (previously, the farmable items text would be left blank on Sundays).