### PR TITLE
Allow usage of localized weapon name in WishCounterAddModal

### DIFF
--- a/src/components/WeaponSelect.svelte
+++ b/src/components/WeaponSelect.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { t } from 'svelte-i18n';
-  import { createEventDispatcher } from 'svelte';
+  import { t, locale } from 'svelte-i18n';
+  import { createEventDispatcher, onMount } from 'svelte';
   import VirtualList from './VirtualList.svelte';
   import { fade } from 'svelte/transition';
   import { mdiChevronDown, mdiCloseCircle } from '@mdi/js';
@@ -20,6 +20,7 @@
   let container;
   let input;
   let search = '';
+  let weaponListLocalized = {}
 
   function toggleOptions() {
     focused = !focused;
@@ -94,7 +95,9 @@
     .filter((e) => e[1].rarity >= 3)
     .sort((a, b) => a[1].name.localeCompare(b[1].name));
 
-  $: filteredWeapons = weapons.filter((e) => e[1].name.toLowerCase().includes(search.toLowerCase()));
+  $: filteredWeapons = weapons.filter((e) => {
+    return e[1].name.toLowerCase().includes(search.toLowerCase()) || (e[1].id in weaponListLocalized && weaponListLocalized[e[1].id].toLowerCase().includes(search.toLowerCase()))
+  });
   $: maxItemRow = Math.min(6, filteredWeapons.length);
 
   $: nothingSelected = selected === null;
@@ -105,6 +108,16 @@
 
   $: classes = focused ? 'border-primary' : 'border-transparent';
   $: iconClasses = focused ? 'transform rotate-180' : '';
+
+  onMount(async () => {
+    locale.subscribe(async (val) => {
+      const localizedData = await import(`../data/weapons/${val}.json`);
+      weaponListLocalized = Object.values(localizedData).reduce((acc, { id, name }) => ({
+        ...acc, 
+        [id]: name
+      }), {})
+    });
+  });
 </script>
 
 <svelte:window on:click={onWindowClick} on:keydown={onKeyDown} />


### PR DESCRIPTION
### The problem

I'm manually managing my pull in the website. When filtering on weapons, I can't use the localized name to search for one - making me go one by one or searching to google for its english name.
Which is a shame since the app has all the localized data we want. 

### The solution

Loading the weapon data based on the current locale to be able to search in both english or current locale.

### Demo

Including 🥖 

https://github.com/MadeBaruna/paimon-moe/assets/729186/709696c6-ab54-4062-a417-9e9ecda82210

