### PR TITLE
Add handling of removed achievements to the achievement migration function

### DIFF
--- a/src/routes/achievement/index.svelte
+++ b/src/routes/achievement/index.svelte
@@ -301,6 +301,10 @@
       84106, 84109, 84110, 84111, 84112, 
       84113, 84114, 84115
     ];
+    const removedIds = [
+      81416, 81418, 81426, 81429, 81451,
+      81453, 81541, 81569
+    ];
 
     if (checkList['17'] === undefined) {
       checkList['17'] = {};
@@ -310,6 +314,12 @@
       for (const item of movedIds) {
         if (checkList['0'][item] === true) {
           checkList['17'][item] = true;
+          delete checkList['0'][item];
+        }
+      }
+
+      for (const item of removedIds) {
+        if (checkList['0'][item] === true) {
           delete checkList['0'][item];
         }
       }


### PR DESCRIPTION
In the [Update achievements on May 7](https://github.com/MadeBaruna/paimon-moe/commit/c8edfc929e6b04eb6c908ace8c5fb9b0369c03dc) commit, 8 achievements were removed. After that, the calculation of the number of achievements by category showed an incorrect number.

<img width="462" alt="Снимок экрана 2025-06-07 в 06 58 05" src="https://github.com/user-attachments/assets/6740a64f-eca5-43c3-8094-57fe2a82f724" />

The error occurs because the number of completed achievements is calculated only on the data from the save file.

The code already had a function for processing achievement migrations, added processing for deleted achievements.